### PR TITLE
WindowFeatures: lower the minimum window height to 5

### DIFF
--- a/chromium/third_party/WebKit/Source/core/page/WindowFeatures.cpp
+++ b/chromium/third_party/WebKit/Source/core/page/WindowFeatures.cpp
@@ -207,7 +207,7 @@ WindowFeatures::WindowFeatures(const String& dialogFeaturesString, const FloatRe
     // - unadorned: trusted && boolFeature(features, "unadorned");
 
     width = floatFeature(features, "dialogwidth", 100, screenAvailableRect.width(), 620); // default here came from frame size of dialog in MacIE
-    height = floatFeature(features, "dialogheight", 100, screenAvailableRect.height(), 450); // default here came from frame size of dialog in MacIE
+    height = floatFeature(features, "dialogheight", 5, screenAvailableRect.height(), 450); // default here came from frame size of dialog in MacIE
 
     x = floatFeature(features, "dialogleft", screenAvailableRect.x(), screenAvailableRect.maxX() - width, -1);
     xSet = x > 0;


### PR DESCRIPTION
In case the height is expressed in GridUnits, it means it won't be possible to create a window with a height lower than 5gu.

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
