### PR TITLE
storage browser quota: workaround for crash on cache update

### DIFF
--- a/chromium/storage/browser/quota/client_usage_tracker.cc
+++ b/chromium/storage/browser/quota/client_usage_tracker.cc
@@ -348,7 +348,17 @@ void ClientUsageTracker::AddCachedOrigin(
   DCHECK(IsUsageCacheEnabledForOrigin(origin));
 
   std::string host = net::GetHostOrSpecFromURL(origin);
-  int64* usage = &cached_usage_by_host_[host][origin];
+
+  UsageMap& cached_usage_for_host = cached_usage_by_host_[host];
+  UsageMap::iterator found = cached_usage_for_host.find(origin);
+  if (found == cached_usage_for_host.end()) {
+      // try to add it smoothly
+      std::pair<GURL, int64> newPair(origin,0);
+      cached_usage_for_host.insert(newPair);
+  }
+  int64* usage = &(cached_usage_for_host[origin]);
+
+  //int64* usage = &cached_usage_by_host_[host][origin];
   int64 delta = new_usage - *usage;
   *usage = new_usage;
   if (delta) {


### PR DESCRIPTION
When using GCC 5.3.0, we get a crash on the statement:
"int64\* usage = &cached_usage_by_host_[host][origin]"
Apparently adding implicitely a new (GURL,int64) pair in
the host cache results in incorrect code on armv7.
This fix adds the pair more smoothly, step-by-step. The
resulting binary code isn't faulty anymore.

This could be related to the following bug:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69841

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
