### PR TITLE
Detect more ARM FPU models

### DIFF
--- a/chromium/v8/build/toolchain.gypi
+++ b/chromium/v8/build/toolchain.gypi
@@ -168,18 +168,18 @@
               'CAN_USE_ARMV7_INSTRUCTIONS',
             ],
           }],
-          [ 'arm_fpu=="vfpv3-d16" or arm_fpu=="default"', {
+          [ 'arm_fpu=="vfpv3-d16" or arm_fpu=="vfpv4-d16" or arm_fpu=="default"', {
             'defines': [
               'CAN_USE_VFP3_INSTRUCTIONS',
             ],
           }],
-          [ 'arm_fpu=="vfpv3"', {
+          [ 'arm_fpu=="vfpv3" or arm_fpu=="vfpv4"', {
             'defines': [
               'CAN_USE_VFP3_INSTRUCTIONS',
               'CAN_USE_VFP32DREGS',
             ],
           }],
-          [ 'arm_fpu=="neon"', {
+          [ 'arm_fpu=="neon" or arm_neon==1', {
             'defines': [
               'CAN_USE_VFP3_INSTRUCTIONS',
               'CAN_USE_VFP32DREGS',


### PR DESCRIPTION
Ensures vfpv4 models will use vfpv3 instructions, and any architecture
with arm_neon enabled with use NEON instruction.

Change-Id: I14422c471e68f6c492a9a03e7da21a1192d0e770
Reviewed-by: Michal Klocek michal.klocek@qt.io
